### PR TITLE
Update gem version to 0.3.0

### DIFF
--- a/prawnto.gemspec
+++ b/prawnto.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "prawnto_2"
-  s.version = '0.2.6'
+  s.version = '0.3.0'
   s.author = ["Jobber", "Forrest Zeisler", "Nathan Youngman"]
   s.email = ["forrest@getjobber.com"]
   s.date = Time.now.utc.strftime("%Y-%m-%d")


### PR DESCRIPTION
# What's in this PR
This PR bumps up the version to `0.3.0` from `0.2.6`. 
This version adds support for Rails 5.2.

This should have probably been included in #27, but it was forgotten 😬.

When this gets merged in the following command will push the change to rubygems.org
> `gem push prawnto_2-0.3.0.gem`

## References
[Semver](https://semver.org/)