### PR TITLE
Fix Rails 6 Deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
-sudo: false
 language: ruby
 script: bundle exec rspec spec
+
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0
   - jruby-19mode
-gemfile:
-  - spec/gemfiles/Gemfile.rails-3.2.x
-  - spec/gemfiles/Gemfile.rails-4.0.x
-  - spec/gemfiles/Gemfile.rails-4.1.x
+
+  gemfile:
   - spec/gemfiles/Gemfile.rails-4.2.x
+  - spec/gemfiles/Gemfile.rails-5.0.x
+  - spec/gemfiles/Gemfile.rails-6.0.x
+
 matrix:
   exclude:
     - rvm: 1.9.3
-      gemfile: spec/gemfiles/rails-4.1.x.gemfile
-    - rvm: 1.9.3
       gemfile: spec/gemfiles/rails-4.2.x.gemfile
+    - rvm: 1.9.3
+      gemfile: spec/gemfiles/rails-5.0.x.gemfile
+    - rvm: 1.9.3
+      gemfile: spec/gemfiles/rails-6.0.x.gemfile
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,2 @@
 source "https://rubygems.org"
 gemspec
-
-gem "guard"
-gem "guard-rspec"
-
-gem "rails", "5.2.1"
-gem "test-unit"

--- a/lib/prawnto/compile_support.rb
+++ b/lib/prawnto/compile_support.rb
@@ -65,7 +65,7 @@ module Prawnto
     end
 
     def set_content_type
-      @controller.response.content_type ||= Mime[:pdf]
+      @controller.response.content_type = Mime[:pdf]
     end
 
     def set_disposition
@@ -76,6 +76,3 @@ module Prawnto
 
   end
 end
-
-
-

--- a/lib/prawnto/compile_support.rb
+++ b/lib/prawnto/compile_support.rb
@@ -65,7 +65,7 @@ module Prawnto
     end
 
     def set_content_type
-      @controller.response.content_type = Mime[:pdf]
+      @controller.response.content_type = @controller.response.media_type || Mime[:pdf]
     end
 
     def set_disposition

--- a/lib/prawnto/compile_support.rb
+++ b/lib/prawnto/compile_support.rb
@@ -65,7 +65,7 @@ module Prawnto
     end
 
     def set_content_type
-      @controller.response.content_type = @controller.response.media_type || Mime[:pdf]
+      @controller.response.content_type ||= Mime[:pdf]
     end
 
     def set_disposition

--- a/lib/prawnto/template_handlers/base.rb
+++ b/lib/prawnto/template_handlers/base.rb
@@ -3,12 +3,13 @@ require "prawn"
 module Prawnto
   module TemplateHandlers
     class Base
-      def self.call(template)
-        check_for_pdf_redefine(template.source)
+      def self.call(template, source = nil)
+        source ||= template.source
+        check_for_pdf_redefine(source)
 
         "_prawnto_compile_setup;" +
         "renderer = Prawnto::TemplateHandlers::Renderer.new(self);"+
-        "renderer.to_pdf(self) do; #{template.source}\nend;"
+        "renderer.to_pdf(self) do; #{source}\nend;"
       end
 
     private
@@ -21,5 +22,3 @@ module Prawnto
     end
   end
 end
-
-

--- a/prawnto.gemspec
+++ b/prawnto.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "prawnto_2"
-  s.version = '0.3.0'
+  s.version = '0.3.1'
   s.author = ["Jobber", "Forrest Zeisler", "Nathan Youngman"]
   s.email = ["forrest@getjobber.com"]
   s.date = Time.now.utc.strftime("%Y-%m-%d")
@@ -19,6 +19,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
 end

--- a/spec/assets/2.5/default_render-2.3.0.pdf
+++ b/spec/assets/2.5/default_render-2.3.0.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 338
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<48656c6c6f2057> 30 <6f72> -15 <6c6421>] TJ
+ET
+
+
+BT
+36.0 733.512 Td
+/F1.0 12 Tf
+[<696e7374616e63652076> 25 <6172> -15 <696162> 20 <6c65204078203d2031>] TJ
+ET
+
+
+BT
+36.0 719.64 Td
+/F1.0 12 Tf
+[<68656c706572206d6574686f64732077> 10 <6f72> -15 <6b203a20746869732069732066726f6d20612068656c706572>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000604 00000 n 
+0000000870 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+967
+%%EOF

--- a/spec/assets/2.5/dsl_render-2.3.0.pdf
+++ b/spec/assets/2.5/dsl_render-2.3.0.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 350
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<48656c6c6f2057> 30 <6f72> -15 <6c6421202d2044534c>] TJ
+ET
+
+
+BT
+36.0 733.512 Td
+/F1.0 12 Tf
+[<696e7374616e63652076> 25 <6172> -15 <696162> 20 <6c65204078203d2031>] TJ
+ET
+
+
+BT
+36.0 719.64 Td
+/F1.0 12 Tf
+[<68656c706572206d6574686f64732077> 10 <6f72> -15 <6b203a20746869732069732066726f6d20612068656c706572>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000616 00000 n 
+0000000882 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+979
+%%EOF

--- a/spec/assets/2.5/fancy_name-2.3.0.pdf
+++ b/spec/assets/2.5/fancy_name-2.3.0.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 334
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<48656c6c6f2057> 30 <6f72> -15 <6c6421>] TJ
+ET
+
+
+BT
+36.0 733.512 Td
+/F1.0 12 Tf
+[<696e7374616e63652076> 25 <6172> -15 <696162> 20 <6c65204078203d>] TJ
+ET
+
+
+BT
+36.0 719.64 Td
+/F1.0 12 Tf
+[<68656c706572206d6574686f64732077> 10 <6f72> -15 <6b203a20746869732069732066726f6d20612068656c706572>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000600 00000 n 
+0000000866 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+963
+%%EOF

--- a/spec/assets/2.5/instance_var_test-2.3.0.pdf
+++ b/spec/assets/2.5/instance_var_test-2.3.0.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 185
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<436f6d706c65> 30 <78204578616d706c65>] TJ
+ET
+
+
+BT
+36.0 733.512 Td
+/F1.0 12 Tf
+[<4078203d2031>] TJ
+ET
+
+
+BT
+36.0 719.64 Td
+/F1.0 12 Tf
+[<32>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000451 00000 n 
+0000000717 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+814
+%%EOF

--- a/spec/assets/2.5/partial_render-2.3.0.pdf
+++ b/spec/assets/2.5/partial_render-2.3.0.pdf
@@ -1,0 +1,87 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 244
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<626566> 30 <6f726520706172> -40 <7469616c>] TJ
+ET
+
+
+BT
+36.0 733.512 Td
+/F1.0 12 Tf
+[<696e7369646520706172> -40 <7469616c>] TJ
+ET
+
+
+BT
+36.0 719.64 Td
+/F1.0 12 Tf
+[<616674657220706172> -40 <7469616c>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000510 00000 n 
+0000000776 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+873
+%%EOF

--- a/spec/assets/2.5/yield_block_in_helper_test-2.3.0.pdf
+++ b/spec/assets/2.5/yield_block_in_helper_test-2.3.0.pdf
@@ -1,0 +1,80 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [5 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 116
+>>
+stream
+q
+
+BT
+36.0 747.384 Td
+/F1.0 12 Tf
+[<746573742031>] TJ
+ET
+
+
+BT
+36.0 733.512 Td
+/F1.0 12 Tf
+[<746573742032>] TJ
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612 792]
+/CropBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/TrimBox [0 0 612 792]
+/ArtBox [0 0 612 792]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 6 0 R
+>>
+>>
+>>
+endobj
+6 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000000382 00000 n 
+0000000648 00000 n 
+trailer
+<< /Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+745
+%%EOF

--- a/spec/controllers/test_controller_spec.rb
+++ b/spec/controllers/test_controller_spec.rb
@@ -6,7 +6,7 @@ describe TestController do
   describe "simple" do
     it "returns correct PDF" do
       get :default_render, :format => :pdf
-      expect(response).to be_success
+      expect(response).to be_successful
 
       asset_binary = File.open(asset_path("default_render")).read.bytes.to_a
       body_binary = response.body.bytes.to_a
@@ -20,7 +20,7 @@ describe TestController do
 
     it "should render items in a block passed to a helper" do
       get :yield_block_in_helper_test, :format => :pdf
-      expect(response).to be_success
+      expect(response).to be_successful
 
       asset_binary = File.open(asset_path("yield_block_in_helper_test")).read.bytes.to_a
       body_binary = response.body.bytes.to_a
@@ -32,7 +32,7 @@ describe TestController do
   describe "dsl" do
     it "returns correct PDF" do
       get :dsl_render, :format => :pdf
-      expect(response).to be_success
+      expect(response).to be_successful
 
       asset_binary = File.open(asset_path("dsl_render")).read.bytes.to_a
       body_binary = response.body.bytes.to_a
@@ -43,7 +43,7 @@ describe TestController do
   describe "partials" do
     it "renders partials" do
       get :partial_render, :format => :pdf
-      expect(response).to be_success
+      expect(response).to be_successful
 
       asset_binary = File.open(asset_path("partial_render")).read.bytes.to_a
       body_binary = response.body.bytes.to_a
@@ -54,7 +54,7 @@ describe TestController do
   describe "complex headers" do
     it "should return a file with a specified filename" do
       get :filename_test, :format => :pdf
-      expect(response).to be_success
+      expect(response).to be_successful
 
       expect(response.header["Content-Disposition"]).to eq("attachment;filename=\"fancy_name.pdf\"")
     end

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link application.css.scss
+//= link application.js

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -43,6 +43,8 @@ module Dummy
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    # Use Rails 6.1 content_type values
+    config.action_dispatch.return_only_media_type_on_content_type = false
   end
 end
-

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -27,4 +27,7 @@ Dummy::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Do not eager load code on boot.
+  config.eager_load = false
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -9,7 +9,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true
@@ -57,4 +57,7 @@ Dummy::Application.configure do
 
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
+
+  # Eager load code on boot.
+  config.eager_load = true
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -8,7 +8,7 @@ Dummy::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Log error messages when you accidentally call methods on nil
@@ -36,4 +36,12 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Use sort order with tests
+  config.active_support.test_order = :sorted
+
+  # Do not eager load code on boot.
+  config.eager_load = false
+
+
 end

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -4,4 +4,7 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Dummy::Application.config.secret_token = '8f4cbaa2b5177e95c5ec90b258ddd53b6c7efdcb4fa0a5bb098f5fd9d034b82ad56889231e2c2cdba5dc821042bdc4f9919cb94f1522b49f4e1a0a08d6b2d166'
+if Rails::VERSION::MAJOR < 5
+  Dummy::Application.config.secret_token = '8f4cbaa2b5177e95c5ec90b258ddd53b6c7efdcb4fa0a5bb098f5fd9d034b82ad56889231e2c2cdba5dc821042bdc4f9919cb94f1522b49f4e1a0a08d6b2d166'
+end
+Dummy::Application.config.secret_key_base = '6e645b1c4eb2351e8e90ae0194ad60f6f3c6e2e77e92c352e87e39e075e2ce0e22ef35fb813681ab23fb735ea54046c613beb03885946167159e4370c7afe3a4'

--- a/spec/gemfiles/Gemfile.rails-5.0.x
+++ b/spec/gemfiles/Gemfile.rails-5.0.x
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 gemspec :path => "./../.."
 
+gem "guard"
+gem "guard-rspec"
+
 gem "rails", "~> 5.2.1"
 gem "test-unit" # for Ruby 2.2.0

--- a/spec/gemfiles/Gemfile.rails-6.0.x
+++ b/spec/gemfiles/Gemfile.rails-6.0.x
@@ -4,5 +4,5 @@ gemspec :path => "./../.."
 gem "guard"
 gem "guard-rspec"
 
-gem "rails", "~> 4.2.0"
+gem "rails", "~> 6.0.3.3"
 gem "test-unit" # for Ruby 2.2.0

--- a/spec/integrations/pdf_emailer_spec.rb
+++ b/spec/integrations/pdf_emailer_spec.rb
@@ -3,19 +3,19 @@ require File.expand_path("../spec_helper.rb", File.dirname(__FILE__))
 describe PdfEmailer do
   describe "email_with_attachment" do
     before(:all) do
-      @email = PdfEmailer.email_with_attachment.deliver 
+      @email = PdfEmailer.email_with_attachment.deliver_now
     end
-    
+
     it "should have the plain text on the body" do
       expect(@email.encoded).to include "text\/plain"
       expect(@email.encoded).to include "Please see attached PDF"
     end
-    
+
     it "should have the PDF attached" do
       expect(@email.encoded).to include "application\/pdf"
       expect(@email.encoded).to include "Content-Disposition: attachment;"
       expect(@email.encoded).to include "filename=hello_world.pdf"
     end
-    
+
   end
 end


### PR DESCRIPTION
Ran into some deprecations while running this gem under Rails 6 (e.g. #30).

Updated the base template handler to accept two parameters with a fallback so it should still work on earlier Rails versions. Forced setting the response content_type to PDF, rather than setting it only if not already set. 

Also did some spec & config cleanup to match new Rails 6 standards, and regenerated the test PDFs for Ruby 2.5 and prawn 2.3.0