### PR TITLE
make method_missing work with ruby 3 (fixed translation helper calls)

### DIFF
--- a/lib/prawnto/template_handlers/renderer.rb
+++ b/lib/prawnto/template_handlers/renderer.rb
@@ -45,20 +45,20 @@ module Prawnto
       end
 
       # This method is a little hacky with pushing the instance variables back. I would prefer to use bindings, but wasn't having much luck.
-      def method_missing(m, *args, &block)
+      def method_missing(m, ...)
         begin
           super
         rescue
           if pdf.respond_to?(m.to_s)
-            pdf.send(m, *args, &block)
+            pdf.send(m, ...)
           elsif @calling_object.respond_to?(m.to_s)
             push_instance_variables_to @calling_object
-            res = @calling_object.send(m, *args, &block)
+            res = @calling_object.send(m, ...)
             copy_instance_variables_from @calling_object
             res
           elsif @calling_object != @view_context and @view_context.respond_to?(m.to_s)
             push_instance_variables_to @view_context
-            res = @view_context.send(m, *args, &block)
+            res = @view_context.send(m, ...)
             copy_instance_variables_from @view_context
             res
           else


### PR DESCRIPTION
In Ruby 3, the syntax for "all parameters" changed. So for Ruby 3 compatibility, the method_missing implementation needs to be changed from

```
def method_missing(name, *args, &block)
  @object.send(name, *args, &block)
```

to
```
def method_missing(name, ...)
  @object.send(name, ...)

```

This is a breaking change unfortunately.